### PR TITLE
Allow configuring final image format

### DIFF
--- a/API.md
+++ b/API.md
@@ -14,7 +14,7 @@
 
 ## renderThumbnail
 
-[index.js:71-96](https://github.com/mapbox/geojson-thumbnail/blob/b2f6828e35d516db29e0a3198e328b3ab27900f3/index.js#L71-L96 "Source code on GitHub")
+[index.js:74-108](https://github.com/mapbox/geojson-thumbnail/blob/9f0b5f5a7e1315211c8258a66cc348761dd2798f/index.js#L74-L108 "Source code on GitHub")
 
 Render a thumbnmail from a GeoJSON feature
 
@@ -24,10 +24,13 @@ Render a thumbnmail from a GeoJSON feature
 -   `callback` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** Callback called with rendered imageonce finished
 -   `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
     -   `options.backgroundTileJSON` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Provide a custom TileJSON for the background layer
+    -   `options.thumbnailEncoding` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Provide Mapnik image encoding options used to create the thumbnail <https://github.com/mapnik/mapnik/wiki/Image-IO>
+    -   `options.blendFormat` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Format to use when blended together with the background image. <https://github.com/mapbox/node-blend#options>
+    -   `options.blendPngCompression` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Range from 1-9 specifying how good the compression level should be <https://github.com/mapbox/node-blend#options>
 
 ## mapboxStreets
 
-[lib/sources.js:8-24](https://github.com/mapbox/geojson-thumbnail/blob/b2f6828e35d516db29e0a3198e328b3ab27900f3/lib/sources.js#L8-L24 "Source code on GitHub")
+[lib/sources.js:8-24](https://github.com/mapbox/geojson-thumbnail/blob/9f0b5f5a7e1315211c8258a66cc348761dd2798f/lib/sources.js#L8-L24 "Source code on GitHub")
 
 Mapbox Streets <https://www.mapbox.com/maps/streets/>
 
@@ -39,7 +42,7 @@ Returns **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 ## mapboxSatellite
 
-[lib/sources.js:31-46](https://github.com/mapbox/geojson-thumbnail/blob/b2f6828e35d516db29e0a3198e328b3ab27900f3/lib/sources.js#L31-L46 "Source code on GitHub")
+[lib/sources.js:31-46](https://github.com/mapbox/geojson-thumbnail/blob/9f0b5f5a7e1315211c8258a66cc348761dd2798f/lib/sources.js#L31-L46 "Source code on GitHub")
 
 Mapbox Satellite <https://www.mapbox.com/maps/satellite/>
 
@@ -51,7 +54,7 @@ Returns **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 ## naturalEarth
 
-[lib/sources.js:52-67](https://github.com/mapbox/geojson-thumbnail/blob/b2f6828e35d516db29e0a3198e328b3ab27900f3/lib/sources.js#L52-L67 "Source code on GitHub")
+[lib/sources.js:52-67](https://github.com/mapbox/geojson-thumbnail/blob/9f0b5f5a7e1315211c8258a66cc348761dd2798f/lib/sources.js#L52-L67 "Source code on GitHub")
 
 Natural Earth II raster tiles from <http://naturalearthtiles.lukasmartinelli.ch/>
 
@@ -59,7 +62,7 @@ Returns **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 ## default
 
-[lib/styles.js:10-10](https://github.com/mapbox/geojson-thumbnail/blob/b2f6828e35d516db29e0a3198e328b3ab27900f3/lib/styles.js#L10-L10 "Source code on GitHub")
+[lib/styles.js:10-10](https://github.com/mapbox/geojson-thumbnail/blob/9f0b5f5a7e1315211c8258a66cc348761dd2798f/lib/styles.js#L10-L10 "Source code on GitHub")
 
 A default style that visualizes geometries
 
@@ -67,7 +70,7 @@ Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 ## tileDistance
 
-[lib/zoom.js:10-15](https://github.com/mapbox/geojson-thumbnail/blob/b2f6828e35d516db29e0a3198e328b3ab27900f3/lib/zoom.js#L10-L15 "Source code on GitHub")
+[lib/zoom.js:10-15](https://github.com/mapbox/geojson-thumbnail/blob/9f0b5f5a7e1315211c8258a66cc348761dd2798f/lib/zoom.js#L10-L15 "Source code on GitHub")
 
 Calculate the diagonal distance of a tile
 
@@ -79,7 +82,7 @@ Returns **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 ## diagonalDistance
 
-[lib/zoom.js:26-32](https://github.com/mapbox/geojson-thumbnail/blob/b2f6828e35d516db29e0a3198e328b3ab27900f3/lib/zoom.js#L26-L32 "Source code on GitHub")
+[lib/zoom.js:26-32](https://github.com/mapbox/geojson-thumbnail/blob/9f0b5f5a7e1315211c8258a66cc348761dd2798f/lib/zoom.js#L26-L32 "Source code on GitHub")
 
 Calculate the diagonal distance of a bounding box
 
@@ -97,7 +100,7 @@ Returns **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 ## tileZoomBboxFits
 
-[lib/zoom.js:39-50](https://github.com/mapbox/geojson-thumbnail/blob/b2f6828e35d516db29e0a3198e328b3ab27900f3/lib/zoom.js#L39-L50 "Source code on GitHub")
+[lib/zoom.js:39-50](https://github.com/mapbox/geojson-thumbnail/blob/9f0b5f5a7e1315211c8258a66cc348761dd2798f/lib/zoom.js#L39-L50 "Source code on GitHub")
 
 Find the max zoom level a bounding box would fit in
 
@@ -109,7 +112,7 @@ Returns **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 ## decideZoom
 
-[lib/zoom.js:58-62](https://github.com/mapbox/geojson-thumbnail/blob/b2f6828e35d516db29e0a3198e328b3ab27900f3/lib/zoom.js#L58-L62 "Source code on GitHub")
+[lib/zoom.js:58-62](https://github.com/mapbox/geojson-thumbnail/blob/9f0b5f5a7e1315211c8258a66cc348761dd2798f/lib/zoom.js#L58-L62 "Source code on GitHub")
 
 Given a bounding box of features try to find the best zoom level
 for the tiles to render to stitch image together

--- a/API.md
+++ b/API.md
@@ -14,7 +14,7 @@
 
 ## renderThumbnail
 
-[index.js:74-108](https://github.com/mapbox/geojson-thumbnail/blob/9f0b5f5a7e1315211c8258a66cc348761dd2798f/index.js#L74-L108 "Source code on GitHub")
+[index.js:72-104](https://github.com/mapbox/geojson-thumbnail/blob/834be06462b0b0c3c713f1c3f96a8662840c5fd5/index.js#L72-L104 "Source code on GitHub")
 
 Render a thumbnmail from a GeoJSON feature
 
@@ -24,13 +24,11 @@ Render a thumbnmail from a GeoJSON feature
 -   `callback` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** Callback called with rendered imageonce finished
 -   `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
     -   `options.backgroundTileJSON` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Provide a custom TileJSON for the background layer
-    -   `options.thumbnailEncoding` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Provide Mapnik image encoding options used to create the thumbnail <https://github.com/mapnik/mapnik/wiki/Image-IO>
     -   `options.blendFormat` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Format to use when blended together with the background image. <https://github.com/mapbox/node-blend#options>
-    -   `options.blendPngCompression` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Range from 1-9 specifying how good the compression level should be <https://github.com/mapbox/node-blend#options>
 
 ## mapboxStreets
 
-[lib/sources.js:8-24](https://github.com/mapbox/geojson-thumbnail/blob/9f0b5f5a7e1315211c8258a66cc348761dd2798f/lib/sources.js#L8-L24 "Source code on GitHub")
+[lib/sources.js:8-24](https://github.com/mapbox/geojson-thumbnail/blob/834be06462b0b0c3c713f1c3f96a8662840c5fd5/lib/sources.js#L8-L24 "Source code on GitHub")
 
 Mapbox Streets <https://www.mapbox.com/maps/streets/>
 
@@ -42,7 +40,7 @@ Returns **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 ## mapboxSatellite
 
-[lib/sources.js:31-46](https://github.com/mapbox/geojson-thumbnail/blob/9f0b5f5a7e1315211c8258a66cc348761dd2798f/lib/sources.js#L31-L46 "Source code on GitHub")
+[lib/sources.js:31-46](https://github.com/mapbox/geojson-thumbnail/blob/834be06462b0b0c3c713f1c3f96a8662840c5fd5/lib/sources.js#L31-L46 "Source code on GitHub")
 
 Mapbox Satellite <https://www.mapbox.com/maps/satellite/>
 
@@ -54,7 +52,7 @@ Returns **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 ## naturalEarth
 
-[lib/sources.js:52-67](https://github.com/mapbox/geojson-thumbnail/blob/9f0b5f5a7e1315211c8258a66cc348761dd2798f/lib/sources.js#L52-L67 "Source code on GitHub")
+[lib/sources.js:52-67](https://github.com/mapbox/geojson-thumbnail/blob/834be06462b0b0c3c713f1c3f96a8662840c5fd5/lib/sources.js#L52-L67 "Source code on GitHub")
 
 Natural Earth II raster tiles from <http://naturalearthtiles.lukasmartinelli.ch/>
 
@@ -62,7 +60,7 @@ Returns **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 ## default
 
-[lib/styles.js:10-10](https://github.com/mapbox/geojson-thumbnail/blob/9f0b5f5a7e1315211c8258a66cc348761dd2798f/lib/styles.js#L10-L10 "Source code on GitHub")
+[lib/styles.js:10-10](https://github.com/mapbox/geojson-thumbnail/blob/834be06462b0b0c3c713f1c3f96a8662840c5fd5/lib/styles.js#L10-L10 "Source code on GitHub")
 
 A default style that visualizes geometries
 
@@ -70,7 +68,7 @@ Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 ## tileDistance
 
-[lib/zoom.js:10-15](https://github.com/mapbox/geojson-thumbnail/blob/9f0b5f5a7e1315211c8258a66cc348761dd2798f/lib/zoom.js#L10-L15 "Source code on GitHub")
+[lib/zoom.js:10-15](https://github.com/mapbox/geojson-thumbnail/blob/834be06462b0b0c3c713f1c3f96a8662840c5fd5/lib/zoom.js#L10-L15 "Source code on GitHub")
 
 Calculate the diagonal distance of a tile
 
@@ -82,7 +80,7 @@ Returns **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 ## diagonalDistance
 
-[lib/zoom.js:26-32](https://github.com/mapbox/geojson-thumbnail/blob/9f0b5f5a7e1315211c8258a66cc348761dd2798f/lib/zoom.js#L26-L32 "Source code on GitHub")
+[lib/zoom.js:26-32](https://github.com/mapbox/geojson-thumbnail/blob/834be06462b0b0c3c713f1c3f96a8662840c5fd5/lib/zoom.js#L26-L32 "Source code on GitHub")
 
 Calculate the diagonal distance of a bounding box
 
@@ -100,7 +98,7 @@ Returns **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 ## tileZoomBboxFits
 
-[lib/zoom.js:39-50](https://github.com/mapbox/geojson-thumbnail/blob/9f0b5f5a7e1315211c8258a66cc348761dd2798f/lib/zoom.js#L39-L50 "Source code on GitHub")
+[lib/zoom.js:39-50](https://github.com/mapbox/geojson-thumbnail/blob/834be06462b0b0c3c713f1c3f96a8662840c5fd5/lib/zoom.js#L39-L50 "Source code on GitHub")
 
 Find the max zoom level a bounding box would fit in
 
@@ -112,7 +110,7 @@ Returns **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 ## decideZoom
 
-[lib/zoom.js:58-62](https://github.com/mapbox/geojson-thumbnail/blob/9f0b5f5a7e1315211c8258a66cc348761dd2798f/lib/zoom.js#L58-L62 "Source code on GitHub")
+[lib/zoom.js:58-62](https://github.com/mapbox/geojson-thumbnail/blob/834be06462b0b0c3c713f1c3f96a8662840c5fd5/lib/zoom.js#L58-L62 "Source code on GitHub")
 
 Given a bounding box of features try to find the best zoom level
 for the tiles to render to stitch image together

--- a/bin/geojson-thumbnail.js
+++ b/bin/geojson-thumbnail.js
@@ -15,15 +15,12 @@ program
 const run = (input, output) => {
   const geojson = JSON.parse(fs.readFileSync(input));
   const options = {
-    backgroundTileJSON: sources.naturalEarth()
+    backgroundTileJSON: sources.mapboxSatellite(process.env.MapboxAccessToken)
   };
 
   if (output.endsWith('.png')) {
     options.blendFormat = 'png';
-    options.blendPngCompression = 3;
   } else if (output.endsWith('.jpg')) {
-    // options.thumbnailEncoding = 'jpeg80';
-    options.thumbnailEncoding = 'png8:m=h:z=3';
     options.blendFormat = 'jpeg';
   }
 

--- a/bin/geojson-thumbnail.js
+++ b/bin/geojson-thumbnail.js
@@ -14,6 +14,19 @@ program
 
 const run = (input, output) => {
   const geojson = JSON.parse(fs.readFileSync(input));
+  const options = {
+    backgroundTileJSON: sources.naturalEarth()
+  };
+
+  if (output.endsWith('.png')) {
+    options.blendFormat = 'png';
+    options.blendPngCompression = 3;
+  } else if (output.endsWith('.jpg')) {
+    // options.thumbnailEncoding = 'jpeg80';
+    options.thumbnailEncoding = 'png8:m=h:z=3';
+    options.blendFormat = 'jpeg';
+  }
+
   index.renderThumbnail(geojson, function onImageRendered(err, image, headers, stats) {
     if (err) throw err;
     fs.writeFile(output, image, (err) => {
@@ -25,9 +38,7 @@ const run = (input, output) => {
         Math.floor(image.length / 1024), 'kb'
       );
     });
-  }, {
-    backgroundTileJSON: sources.naturalEarth()
-  });
+  }, options);
 };
 
 if (program.args.length < 2) {

--- a/index.js
+++ b/index.js
@@ -67,6 +67,9 @@ function bestRenderParams(geojson, backgroundTileJSON) {
  * @param {Function} callback - Callback called with rendered imageonce finished
  * @param {Object} options
  * @param {Object} [options.backgroundTileJSON] - Provide a custom TileJSON for the background layer
+ * @param {string} [options.thumbnailEncoding] - Provide Mapnik image encoding options used to create the thumbnail https://github.com/mapnik/mapnik/wiki/Image-IO
+ * @param {string} [options.blendFormat] - Format to use when blended together with the background image. https://github.com/mapbox/node-blend#options
+ * @param {string} [options.blendPngCompression] - Range from 1-9 specifying how good the compression level should be https://github.com/mapbox/node-blend#options
  */
 function renderThumbnail(geojson, callback, options) {
   if (!geojson) throw new Error('Cannot render thumbnail without GeoJSON passed');
@@ -83,7 +86,7 @@ function renderThumbnail(geojson, callback, options) {
 
   const imageOptions = {
     tileSize: options.tileSize,
-    encoding: options.imageEncoding
+    encoding: options.thumbnailEncoding
   };
 
   template.templatizeStylesheet(options.stylesheet, (err, template) => {
@@ -92,6 +95,8 @@ function renderThumbnail(geojson, callback, options) {
       const overlaySource = new thumbnail.ThumbnailSource(geojson, template, imageOptions, options.mapOptions);
       const blendSource = new blend.BlendRasterSource(backgroundSource, overlaySource);
       const renderParams = Object.assign(bestRenderParams(geojson, options.backgroundTileJSON), {
+        format: options.blendFormat || 'png',
+        compression: options.blendPngCompression || 6,
         tileSize: options.tileSize,
         getTile: blendSource.getTile
       });

--- a/index.js
+++ b/index.js
@@ -67,9 +67,7 @@ function bestRenderParams(geojson, backgroundTileJSON) {
  * @param {Function} callback - Callback called with rendered imageonce finished
  * @param {Object} options
  * @param {Object} [options.backgroundTileJSON] - Provide a custom TileJSON for the background layer
- * @param {string} [options.thumbnailEncoding] - Provide Mapnik image encoding options used to create the thumbnail https://github.com/mapnik/mapnik/wiki/Image-IO
  * @param {string} [options.blendFormat] - Format to use when blended together with the background image. https://github.com/mapbox/node-blend#options
- * @param {string} [options.blendPngCompression] - Range from 1-9 specifying how good the compression level should be https://github.com/mapbox/node-blend#options
  */
 function renderThumbnail(geojson, callback, options) {
   if (!geojson) throw new Error('Cannot render thumbnail without GeoJSON passed');
@@ -85,8 +83,7 @@ function renderThumbnail(geojson, callback, options) {
   options.tileSize = options.backgroundTileJSON.tileSize || 256;
 
   const imageOptions = {
-    tileSize: options.tileSize,
-    encoding: options.thumbnailEncoding
+    tileSize: options.tileSize
   };
 
   template.templatizeStylesheet(options.stylesheet, (err, template) => {
@@ -96,7 +93,6 @@ function renderThumbnail(geojson, callback, options) {
       const blendSource = new blend.BlendRasterSource(backgroundSource, overlaySource);
       const renderParams = Object.assign(bestRenderParams(geojson, options.backgroundTileJSON), {
         format: options.blendFormat || 'png',
-        compression: options.blendPngCompression || 6,
         tileSize: options.tileSize,
         getTile: blendSource.getTile
       });

--- a/lib/thumbnail.js
+++ b/lib/thumbnail.js
@@ -19,6 +19,7 @@ class ThumbnailSource extends events.EventEmitter {
   constructor(geojson, template, imageOptions, mapOptions) {
     super();
     this._size = imageOptions.tileSize || 256;
+    this._imageEncoding = imageOptions.encoding || 'png8:m=h:z=1';
     this._bufferSize = 64;
     this._mapOptions = mapOptions || {};
     this._xml = template.replace('{{geojson}}', JSON.stringify(geojson));
@@ -33,6 +34,7 @@ class ThumbnailSource extends events.EventEmitter {
    * @param {function} callback
    */
   getTile(z, x, y, callback) {
+    const encoding = this._imageEncoding;
     const size = this._size;
     const map = new mapnik.Map(size, size);
     map.bufferSize = this._bufferSize;
@@ -44,7 +46,7 @@ class ThumbnailSource extends events.EventEmitter {
         map.extent = sm.bbox(x, y, z, false, '900913');
         map.render(new mapnik.Image(size, size), {}, function onImageRendered(err, image) {
           if (err) return callback(err);
-          image.encode('png8:m=h:z=1', function onImageEncoded(err, encodedImage) {
+          image.encode(encoding, function onImageEncoded(err, encodedImage) {
             callback(err, encodedImage);
           });
         });

--- a/lib/thumbnail.js
+++ b/lib/thumbnail.js
@@ -19,6 +19,7 @@ class ThumbnailSource extends events.EventEmitter {
   constructor(geojson, template, imageOptions, mapOptions) {
     super();
     this._size = imageOptions.tileSize || 256;
+    // see image encoding options: https://github.com/mapnik/mapnik/wiki/Image-IO
     this._imageEncoding = imageOptions.encoding || 'png8:m=h:z=1';
     this._bufferSize = 64;
     this._mapOptions = mapOptions || {};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,16 +6,16 @@ const sources = require('../lib/sources');
 const index = require('../index');
 
 
-function assertThumbnailRenders(fixturePath, assert) {
+function assertThumbnailRenders(fixturePath, assert, options) {
   const geojson = JSON.parse(fs.readFileSync(path.join(__dirname, fixturePath)));
 
   index.renderThumbnail(geojson, (err, image) => {
     assert.ifError(err, 'preview should not fail');
     assert.true(image.length > 10 * 1024, `preview image should have reasonable image size ${image.length}`);
     assert.end();
-  }, {
+  }, Object.assign({
     backgroundTileJSON: sources.naturalEarth()
-  });
+  }, options));
 }
 
 tape('renderThumbnail water', (assert) => {
@@ -32,4 +32,16 @@ tape('renderThumbnail building', (assert) => {
 
 tape('renderThumbnail peak', (assert) => {
   assertThumbnailRenders('/fixtures/peak.geojson', assert);
+});
+
+tape('renderThumbnail as png with best compression', (assert) => {
+  assertThumbnailRenders('/fixtures/peak.geojson', assert, {
+    imageEncoding: 'png8:m=h:z=8'
+  });
+});
+
+tape('renderThumbnail as jpg', (assert) => {
+  assertThumbnailRenders('/fixtures/peak.geojson', assert, {
+    imageEncoding: 'jpeg80'
+  });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -37,8 +37,7 @@ tape('renderThumbnail peak', (assert) => {
 tape('renderThumbnail as png with better compression', (assert) => {
   assertThumbnailRenders('/fixtures/peak.geojson', assert, {
     thumbnailEncoding: 'png8:m=h:z=8',
-    blendFormat: 'png',
-    blendCompression: 8
+    blendFormat: 'png'
   });
 });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -34,14 +34,17 @@ tape('renderThumbnail peak', (assert) => {
   assertThumbnailRenders('/fixtures/peak.geojson', assert);
 });
 
-tape('renderThumbnail as png with best compression', (assert) => {
+tape('renderThumbnail as png with better compression', (assert) => {
   assertThumbnailRenders('/fixtures/peak.geojson', assert, {
-    imageEncoding: 'png8:m=h:z=8'
+    thumbnailEncoding: 'png8:m=h:z=8',
+    blendFormat: 'png',
+    blendCompression: 8
   });
 });
 
 tape('renderThumbnail as jpg', (assert) => {
   assertThumbnailRenders('/fixtures/peak.geojson', assert, {
-    imageEncoding: 'jpeg80'
+    thumbnailEncoding: 'jpeg80',
+    blendFormat: 'jpeg'
   });
 });


### PR DESCRIPTION
Allows to switch between `jpg` and `png`.
We should squash merge this.

TODO:
- [x] Test publish this library and test in downstream dependencies @lukasmartinelli