### PR TITLE
Render only single shape

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-- '4'
 - '6'
 before_install:
 - npm install coveralls

--- a/bin/geojson-thumbnail.js
+++ b/bin/geojson-thumbnail.js
@@ -10,15 +10,21 @@ const index = require('../index');
 program
   .usage('<input file> <output file>')
   .description('Render a GeoJSON thumbnail')
+  .option('--background')
+  .option('--stylesheet <f>')
   .option('--min-zoom <n>')
   .option('--max-zoom <n>')
   .parse(process.argv);
 
-const run = (input, output, minZoom, maxZoom) => {
+const run = (input, output, minZoom, maxZoom, hasBackground, stylesheetPath) => {
   const geojson = JSON.parse(fs.readFileSync(input));
   const options = {
-    backgroundTileJSON: sources.mapboxSatellite(process.env.MapboxAccessToken)
+    backgroundTileJSON: hasBackground ? sources.mapboxSatellite(process.env.MapboxAccessToken) : null
   };
+
+  if (stylesheetPath) {
+    options.stylesheet = fs.readFileSync(path.normalize(stylesheetPath), 'utf8');
+  }
 
   if (output.endsWith('.png')) {
     options.blendFormat = 'png';
@@ -51,6 +57,6 @@ const run = (input, output, minZoom, maxZoom) => {
 if (program.args.length < 2) {
   program.outputHelp();
 } else {
-  run(program.args[0], program.args[1], program.minZoom, program.maxZoom);
+  run(program.args[0], program.args[1], program.minZoom, program.maxZoom, program.background, program.stylesheet);
 }
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const abaculus = require('@mapbox/abaculus');
 
 function renderOverlay(geojson, options, template, callback) {
   const overlaySource = new thumbnail.ThumbnailSource(geojson, template, options.image, options.map);
-  const renderParams = Object.assign(bestRenderParams(geojson, options.minzoom, options.maxzoom), {
+  const renderParams = Object.assign(bestRenderParams(geojson, options.minzoom, options.maxzoom, !!options.noPadding), {
     format: options.blendFormat || 'png',
     tileSize: options.tileSize,
     getTile: overlaySource.getTile.bind(overlaySource)
@@ -56,6 +56,7 @@ function renderThumbnail(geojson, callback, options) {
   if (typeof callback !== 'function') throw new Error('Callback needs to be a function not an object');
 
   options = Object.assign({
+    noPadding: false,
     minzoom: 0,
     maxzoom: 22,
     stylesheet: styles.default,

--- a/index.js
+++ b/index.js
@@ -4,75 +4,50 @@ const styles = require('./lib/styles');
 const template = require('./lib/template');
 const thumbnail = require('./lib/thumbnail');
 const blend = require('./lib/blend');
-const zoom = require('./lib/zoom');
+const bestRenderParams = require('./lib/renderparams');
 const TileJSON = require('@mapbox/tilejson');
-const bbox = require('@turf/bbox');
 const abaculus = require('@mapbox/abaculus');
-const sm = new (require('@mapbox/sphericalmercator'))();
 
-function bestRenderParams(geojson, backgroundTileJSON, minZoom, maxZoom) {
-  let optimalZoom = zoom.decideZoom(bbox(geojson));
-  if (optimalZoom > backgroundTileJSON.maxzoom) {
-    optimalZoom = backgroundTileJSON.maxzoom;
-  }
-  if (optimalZoom < backgroundTileJSON.minzoom) {
-    optimalZoom = backgroundTileJSON.minzoom;
-  }
-  optimalZoom = Math.max(minZoom, Math.min(maxZoom, optimalZoom));
+function renderOverlay(geojson, options, template, callback) {
+  const overlaySource = new thumbnail.ThumbnailSource(geojson, template, options.image, options.map);
+  const renderParams = Object.assign(bestRenderParams(geojson, options.minzoom, options.maxzoom), {
+    format: options.blendFormat || 'png',
+    tileSize: options.tileSize,
+    getTile: overlaySource.getTile.bind(overlaySource)
+  });
+  abaculus(renderParams, (err, image, headers) => {
+    callback(err, image, headers, overlaySource.stats);
+  });
+}
 
-  function paddedExtent(geojson) {
-    const extent = bbox(geojson);
-
-    const topRight = sm.px([extent[2], extent[3]], optimalZoom);
-    const bottomLeft = sm.px([extent[0], extent[1]], optimalZoom);
-    const width = topRight[0] - bottomLeft[0];
-    const height = bottomLeft[1] - topRight[1];
-    const minSize = 200;
-
-    // TODO: Padding is super hacky without any real background checking what we should do
-    let minPad = Math.abs(sm.ll([0, 0], optimalZoom)[0] - sm.ll([10, 10], optimalZoom)[0]);
-
-    if (width < minSize) {
-      minPad = Math.abs(sm.ll([0, 0], optimalZoom)[0] - sm.ll([minSize - width, 10], optimalZoom)[0]);
-    }
-    if (height < minSize) {
-      minPad = Math.abs(sm.ll([0, 0], optimalZoom)[0] - sm.ll([minSize - height, 10], optimalZoom)[0]);
-    }
-
-    const pad = Math.max(
-      Math.abs(extent[2] - extent[0]) * 0.05,
-      Math.abs(extent[3] - extent[1]) * 0.05,
-      minPad,
-      0.001
-    );
-    extent[0] -= pad;
-    extent[1] -= pad;
-    extent[2] += pad;
-    extent[3] += pad;
-    return extent;
-  }
-
-  const bounds = paddedExtent(geojson);
-  return {
-    // ensure zoom is within min and max bounds configured for thumbnail
-    zoom: optimalZoom,
-    scale: 1,
-    format: 'png',
-    bbox: bounds,
-    limit: 36000,
-    tileSize: 256
-  };
+function renderOverlayWithBackground(geojson, options, template, callback) {
+  const backgroundUri =  { data: options.background.tilejson };
+  new TileJSON(backgroundUri, (err, backgroundSource) => {
+    const overlaySource = new thumbnail.ThumbnailSource(geojson, template, options.image, options.map);
+    const blendSource = new blend.BlendRasterSource(backgroundSource, overlaySource);
+    const renderParams = Object.assign(bestRenderParams(geojson, options.minzoom, options.maxzoom), {
+      format: options.blendFormat || 'png',
+      tileSize: options.tileSize,
+      getTile: blendSource.getTile
+    });
+    abaculus(renderParams, (err, image, headers) => {
+      callback(err, image, headers, blendSource.stats);
+    });
+  });
 }
 
 /**
  * Render a thumbnmail from a GeoJSON feature
  * @param {Object} geojson - GeoJSON Feature or FeatureCollection
- * @param {Function} callback - Callback called with rendered imageonce finished
+ * @param {Function} callback - Callback called with rendered image once finished
  * @param {Object} options
- * @param {Object} [options.backgroundTileJSON] - Provide a custom TileJSON for the background layer
- * @param {Number} [options.thumbnailMinZoom] - Specify a min zoom level to render thumbnail
- * @param {Number} [options.thumbnailMaxZoom] - Specify a max zoom level to render thumbnail
- * @param {string} [options.blendFormat] - Format to use when blended together with the background image. https://github.com/mapbox/node-blend#options
+ * @param {Object} [options.image] - Image options
+ * @param {Object} [options.map] - Map options
+ * @param {Object} [options.background] - Render thumbnail on a background
+ * @param {Object} [options.background.tilejson] - TileJSON for the background layer
+ * @param {Number} [options.minzoom] - Specify a min zoom level to render thumbnail
+ * @param {Number} [options.maxzoom] - Specify a max zoom level to render thumbnail
+ * @param {string} [options.format] - Format to use when blended together with the background image. https://github.com/mapbox/node-blend#options
  */
 function renderThumbnail(geojson, callback, options) {
   if (!geojson) throw new Error('Cannot render thumbnail without GeoJSON passed');
@@ -81,55 +56,28 @@ function renderThumbnail(geojson, callback, options) {
   if (typeof callback !== 'function') throw new Error('Callback needs to be a function not an object');
 
   options = Object.assign({
-    thumbnailMinZoom: 0,
-    thumbnailMaxZoom: 22,
+    minzoom: 0,
+    maxzoom: 22,
     stylesheet: styles.default,
-    // backgroundTileJSON: sources.naturalEarth(),
-    backgroundTileJSON: sources.mapboxSatellite(process.env.MapboxAccessToken)
+    tileSize: 256
   }, options);
-  options.tileSize = (options.backgroundTileJSON && options.backgroundTileJSON.tileSize) || 256;
 
-  const imageOptions = {
+  options.image = Object.assign({
     tileSize: options.tileSize
-  };
+  }, options.image);
 
-  function renderOnlyOverlay(template) {
-    const overlaySource = new thumbnail.ThumbnailSource(geojson, template, imageOptions, options.mapOptions);
-    const renderParams = Object.assign(bestRenderParams(geojson, {
-      maxzoom: 22,
-      minzoom: 0
-    }, options.thumbnailMinZoom, options.thumbnailMaxZoom), {
-      format: options.blendFormat || 'png',
-      tileSize: options.tileSize,
-      getTile: overlaySource.getTile.bind(overlaySource)
-    });
-    abaculus(renderParams, (err, image, headers) => {
-      callback(err, image, headers, overlaySource.stats);
-    });
-  }
-
-  function renderBlended(template) {
-    const backgroundUri =  { data: options.backgroundTileJSON };
-    new TileJSON(backgroundUri, (err, backgroundSource) => {
-      const overlaySource = new thumbnail.ThumbnailSource(geojson, template, imageOptions, options.mapOptions);
-      const blendSource = new blend.BlendRasterSource(backgroundSource, overlaySource);
-      const renderParams = Object.assign(bestRenderParams(geojson, options.backgroundTileJSON, options.thumbnailMinZoom, options.thumbnailMaxZoom), {
-        format: options.blendFormat || 'png',
-        tileSize: options.tileSize,
-        getTile: blendSource.getTile
-      });
-      abaculus(renderParams, (err, image, headers) => {
-        callback(err, image, headers, blendSource.stats);
-      });
-    });
+  // Background source zoom always limits the possible min and maxzoom
+  if (options.background && options.background.tilejson) {
+    options.minzoom = Math.max(options.minzoom, options.background.tilejson.minzoom);
+    options.maxzoom = Math.min(options.maxzoom, options.background.tilejson.maxzoom);
   }
 
   template.templatizeStylesheet(options.stylesheet, (err, template) => {
     // If no background specified we only render the overlay
-    if (!options.backgroundTileJSON) {
-      return renderOnlyOverlay(template);
+    if (options.background && options.background.tilejson) {
+      return renderOverlayWithBackground(geojson, options, template, callback);
     } else {
-      return renderBlended(template);
+      return renderOverlay(geojson, options, template, callback);
     }
   });
 }

--- a/lib/renderparams.js
+++ b/lib/renderparams.js
@@ -1,0 +1,62 @@
+'use strict';
+const zoom = require('./zoom');
+const bbox = require('@turf/bbox');
+const sm = new (require('@mapbox/sphericalmercator'))();
+
+module.exports = bestRenderParams;
+
+function bestRenderParams(geojson, minZoom, maxZoom, noPadding) {
+  let optimalZoom = zoom.decideZoom(bbox(geojson));
+  optimalZoom = Math.max(minZoom, Math.min(maxZoom, optimalZoom));
+
+  function addPadding(extent, pad) {
+    extent[0] -= pad;
+    extent[1] -= pad;
+    extent[2] += pad;
+    extent[3] += pad;
+    return extent;
+  }
+
+  function paddedExtent(geojson) {
+    const extent = bbox(geojson);
+
+    const topRight = sm.px([extent[2], extent[3]], optimalZoom);
+    const bottomLeft = sm.px([extent[0], extent[1]], optimalZoom);
+    const width = topRight[0] - bottomLeft[0];
+    const height = bottomLeft[1] - topRight[1];
+    const minSize = 200;
+
+    // TODO: Padding is super hacky without any real background checking what we should do
+    let minPad = Math.abs(sm.ll([0, 0], optimalZoom)[0] - sm.ll([10, 10], optimalZoom)[0]);
+
+    if (width < minSize) {
+      minPad = Math.abs(sm.ll([0, 0], optimalZoom)[0] - sm.ll([minSize - width, 10], optimalZoom)[0]);
+    }
+    if (height < minSize) {
+      minPad = Math.abs(sm.ll([0, 0], optimalZoom)[0] - sm.ll([minSize - height, 10], optimalZoom)[0]);
+    }
+
+    const pad = Math.max(
+      Math.abs(extent[2] - extent[0]) * 0.05,
+      Math.abs(extent[3] - extent[1]) * 0.05,
+      minPad,
+      0.001
+    );
+    extent[0] -= pad;
+    extent[1] -= pad;
+    extent[2] += pad;
+    extent[3] += pad;
+    return extent;
+  }
+
+  const bounds = noPadding ? addPadding(bbox(geojson), 0.0001) : paddedExtent(geojson);
+  return {
+    // ensure zoom is within min and max bounds configured for thumbnail
+    zoom: optimalZoom,
+    scale: 1,
+    format: 'png',
+    bbox: bounds,
+    limit: 36000,
+    tileSize: 256
+  };
+}

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -5,7 +5,10 @@ const path = require('path');
 module.exports = {
   /**
    * A default style that visualizes geometries
-   * @returns {string} Mapnik Stylesheet
    */
-  default: fs.readFileSync(path.normalize(__dirname + '/../styles/default.xml'), 'utf8')
+  default: fs.readFileSync(path.normalize(__dirname + '/../styles/default.xml'), 'utf8'),
+  /**
+   * A style that draws black shapes for geoms
+   */
+  black: fs.readFileSync(path.normalize(__dirname + '/../styles/black.xml'), 'utf8')
 };

--- a/lib/thumbnail.js
+++ b/lib/thumbnail.js
@@ -24,6 +24,11 @@ class ThumbnailSource extends events.EventEmitter {
     this._bufferSize = 64;
     this._mapOptions = mapOptions || {};
     this._xml = template.replace('{{geojson}}', JSON.stringify(geojson));
+
+    this.stats = {
+      requested: 0,
+      rendered: 0
+    };
   }
 
   /**
@@ -42,6 +47,7 @@ class ThumbnailSource extends events.EventEmitter {
 
     try {
       // TODO: It is not smart or performant to create a new mapnik instance for each tile rendering
+      this.stats.rendered += 1;
       map.fromString(this._xml, this._mapOptions, function onMapLoaded(err) {
         if (err) return callback(err);
         map.extent = sm.bbox(x, y, z, false, '900913');

--- a/package-lock.json
+++ b/package-lock.json
@@ -3757,6 +3757,11 @@
       "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
       "dev": true
     },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g=="
+    },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@turf/distance": "^5.1.5",
     "@turf/helpers": "^6.0.0-beta.3",
     "commander": "^2.13.0",
+    "get-stdin": "^6.0.0",
     "mapnik": "^3.7.0",
     "xml2js": "^0.4.19"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Generate thumbnails for GeoJSON features",
   "main": "index.js",
   "engines": {
-    "node": "4.3"
+    "node": ">6.0"
   },
   "bin": {
     "geojson-thumbnail": "bin/geojson-thumbnail.js"

--- a/styles/black.mss
+++ b/styles/black.mss
@@ -1,0 +1,36 @@
+@w-lines: 2;
+
+Map {
+  background-color: #fff; //For Style guide
+}
+
+#features {
+  //Style for polygon
+  ['mapnik::geometry_type'=polygon] {
+     line-color:black;
+     polygon-fill: black;
+  }
+
+  //Style for lines
+  ['mapnik::geometry_type'=linestring] {
+  
+    [zoom<14] {
+      line-width: @w-lines*1.5;
+    }
+    [zoom>=14] {
+      line-width: @w-lines*3;
+    }
+    
+    line-width: @w-lines;
+    line-cap:round;
+  }
+  
+  ['mapnik::geometry_type'=point] {
+    marker-width:12;
+    marker-type:ellipse;
+    marker-allow-overlap: true;
+    marker-ignore-placement: true;
+    marker-placement: point;
+    marker-fill: black;
+  }
+}

--- a/styles/black.xml
+++ b/styles/black.xml
@@ -15,12 +15,12 @@
   <Rule>
     <MaxScaleDenominator>50000</MaxScaleDenominator>
     <Filter>([mapnik::geometry_type] = linestring)</Filter>
-    <LineSymbolizer stroke-width="6" stroke-linecap="round" />
+    <LineSymbolizer stroke-width="6" />
   </Rule>
   <Rule>
     <MinScaleDenominator>50000</MinScaleDenominator>
     <Filter>([mapnik::geometry_type] = linestring)</Filter>
-    <LineSymbolizer stroke-width="3" stroke-linecap="round" />
+    <LineSymbolizer stroke-width="3" />
   </Rule>
   <Rule>
     <Filter>([mapnik::geometry_type] = point)</Filter>

--- a/styles/black.xml
+++ b/styles/black.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Map[]>
+<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="#ffffff" font-directory="fonts/">
+
+<Parameters>
+  <Parameter name="bounds">-180,-85.0511,180,85.0511</Parameter>
+  <Parameter name="center">-4.2629,-2.753,16</Parameter>
+  <Parameter name="format">png8:m=h</Parameter>
+  <Parameter name="maxzoom">22</Parameter>
+  <Parameter name="minzoom">0</Parameter>
+  <Parameter name="name"><![CDATA[Black Shape Style]]></Parameter>
+</Parameters>
+
+<Style name="features" filter-mode="first">
+  <Rule>
+    <MaxScaleDenominator>50000</MaxScaleDenominator>
+    <Filter>([mapnik::geometry_type] = linestring)</Filter>
+    <LineSymbolizer stroke-width="6" stroke-linecap="round" />
+  </Rule>
+  <Rule>
+    <MinScaleDenominator>50000</MinScaleDenominator>
+    <Filter>([mapnik::geometry_type] = linestring)</Filter>
+    <LineSymbolizer stroke-width="3" stroke-linecap="round" />
+  </Rule>
+  <Rule>
+    <Filter>([mapnik::geometry_type] = point)</Filter>
+    <MarkersSymbolizer width="12" marker-type="ellipse" allow-overlap="true" ignore-placement="true" placement="point" fill="#000000" />
+  </Rule>
+  <Rule>
+    <Filter>([mapnik::geometry_type] = polygon)</Filter>
+    <LineSymbolizer stroke="#000000" />
+    <PolygonSymbolizer fill="#000000" />
+  </Rule>
+</Style>
+<Layer name="features"
+  srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <StyleName>features</StyleName>  </Layer>
+</Map>

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,7 +14,7 @@ function assertThumbnailRenders(fixturePath, assert, options) {
     assert.true(image.length > 10 * 1024, `preview image should have reasonable image size ${image.length}`);
     assert.end();
   }, Object.assign({
-    backgroundTileJSON: sources.naturalEarth()
+    background: { tilejson: sources.naturalEarth() }
   }, options));
 }
 
@@ -36,20 +36,18 @@ tape('renderThumbnail peak', (assert) => {
 
 tape('renderThumbnail as png with better compression', (assert) => {
   assertThumbnailRenders('/fixtures/peak.geojson', assert, {
-    thumbnailEncoding: 'png8:m=h:z=8',
-    blendFormat: 'png'
+    format: 'png'
   });
 });
 
 tape('renderThumbnail as jpg', (assert) => {
   assertThumbnailRenders('/fixtures/peak.geojson', assert, {
-    thumbnailEncoding: 'jpeg80',
-    blendFormat: 'jpeg'
+    format: 'jpeg'
   });
 });
 
 tape('renderThumbnail with max zoom', (assert) => {
   assertThumbnailRenders('/fixtures/peak.geojson', assert, {
-    thumbnailMaxZoom: 4
+    maxzoom: 4
   });
 });


### PR DESCRIPTION
@amishas157 this branch was used for https://github.com/mapbox/cartoshapes.

This PR:
- Changes the whole options format (which means will be a breaking version change)
- Allows rendering **only an overlay without a background**
- Adds a black style which is only the black feature outline
- Adds option to specify overlay stylesheet in CLI
- Move render params guessing into a `renderparams` module
- Refactor `renderThumbnail` into `renderOverlayWithBackground` and `renderOverlay`
- One can also pipe in a feature from stdin now when doing `echo '{}' | render-thumbnail - mythumb.png`
